### PR TITLE
Fix typos in invitation page

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -47,7 +47,7 @@
             <div class="text-overlay-bottom">
                 <h1 class="title-message">
                     <span id="animated-text-1">We are getting</span><br/>
-                    <span id="animated-text-2">Merried !</span>
+                    <span id="animated-text-2">Married !</span>
                 </h1>
             </div>
         </div>
@@ -74,7 +74,7 @@
             </div>
         </div>
         <div class="invitation-img-1">
-            <img src="https://dwp9wba2tw70x.cloudfront.net/img/invi1.jpg" alt="invitaion-1">
+            <img src="https://dwp9wba2tw70x.cloudfront.net/img/invi1.jpg" alt="invitation-1">
         </div>
         <p class="invitation-text">
             '사랑이란 별다른 것이 아니라 <br>
@@ -85,7 +85,7 @@
         </p>
         <div class="invitation-text-from">신랑 원희 · 신부 상은 올림</div>
         <div class="invitation-img-2">
-            <img src="https://dwp9wba2tw70x.cloudfront.net/img/invi2.jpg" alt="invitaion-2">
+            <img src="https://dwp9wba2tw70x.cloudfront.net/img/invi2.jpg" alt="invitation-2">
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- fix typo "Merried" -> "Married"
- correct alt text for invitation images

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68539f0fc3588321993b31825b85cae9